### PR TITLE
Consume libecl as cmake targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - george-edison55-precise-backports
     packages:
       - liblapack-dev
       - valgrind
       - gcc-4.8
       - g++-4.8
       - clang
+      - cmake
+      - cmake-data
 
 install:
     - if [[ "$CC" == "gcc" ]]; then export CXX="g++-4.8"; fi
@@ -66,17 +69,25 @@ before_script:
   - popd
   - popd
   - pushd ..
+  - export PYTHONPATH=$PYTHONPATH:$LIBECL_INSTALL_ROOT/lib/python2.7/dist-packages
   - git clone https://github.com/Statoil/libres
-  - mkdir libecl/build
-  - pushd libecl/build
+  - mkdir libres/build
+  - pushd libres/build
   - export LIBRES_INSTALL_ROOT=$(pwd)/install
-  - cmake .. -DCMAKE_INSTALL_PREFIX=$LIBRES_INSTALL_ROOT -DCMAKE_PREFIX_PATH=$LIBECL_INSTALL_ROOT
+  - cmake .. -DCMAKE_INSTALL_PREFIX=$LIBRES_INSTALL_ROOT
+             -DCMAKE_PREFIX_PATH=$LIBECL_INSTALL_ROOT
+             -DCMAKE_MODULE_PATH=$LIBECL_INSTALL_ROOT/share/cmake/Modules
   - make install
+  - export PYTHONPATH=$PYTHONPATH:$LIBRES_INSTALL_ROOT/lib/python2.7/dist-packages
   - popd
   - popd
   - mkdir build
   - pushd build
-  - cmake -DCMAKE_PREFIX_PATH=$LIBECL_INSTALL_ROOT:$LIBRES_INSTALL_ROOT -DBUILD_TESTS=ON -DBUILD_PYTHON=ON -DERT_DOC=OFF ..
+  - cmake -DCMAKE_PREFIX_PATH=$LIBECL_INSTALL_ROOT
+          -DCMAKE_PREFIX_PATH=$LIBRES_INSTALL_ROOT
+          -DCMAKE_MODULE_PATH=$LIBECL_INSTALL_ROOT/share/cmake/Modules
+          -DBUILD_TESTS=ON -DBUILD_PYTHON=ON -DERT_DOC=OFF
+          ..
 
 script:
   - make && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option( BUILD_TESTS         "Should the tests be built"                         
 option( ERT_DOC             "Build ERT documantation"                                 OFF)
 option( USE_RUNPATH         "Should we embed path to libraries"                       ON)
 
-find_package( libecl REQUIRED )
+find_package( ecl REQUIRED )
 find_package( libres REQUIRED )
 
 
@@ -75,18 +75,6 @@ endif()
 
 if (MSVC)
     add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996" )
-endif()
-
-
-if (ERT_USE_OPENMP)
-  find_package(OpenMP)
-  if (OPENMP_FOUND) 
-     message(STATUS "Enabling OpenMP support")
-     # The actual use of OpenMP is only in the libecl library - the compile flags is only applied there.
-  else()
-     set( ERT_USE_OPENMP OFF )
-     message(STATUS "OpenMP package not found - OpenMP disabled")
-  endif()
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)

--- a/libenkf/applications/ert_tui/CMakeLists.txt
+++ b/libenkf/applications/ert_tui/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 set_source_files_properties( main.c PROPERTIES COMPILE_DEFINITIONS "COMPILE_TIME_STAMP=\"${BUILD_TIME}\";GIT_COMMIT=\"${GIT_COMMIT}\"")
 
 add_executable( ert_tui ${src_list} )
-target_link_libraries( ert_tui enkf sched rms config job_queue analysis ${ECL_LIBRARY} ${UTIL_LIBRARY} )
+target_link_libraries( ert_tui enkf sched rms config job_queue analysis ecl )
 if (USE_RUNPATH)
    add_runpath( ert_tui )
 endif()


### PR DESCRIPTION
The upstream libecl exposes targets, not _LIBRARIES variables, and a
-config.cmake rather than a Find module.