### PR TITLE
Fixed renamings from libres

### DIFF
--- a/libenkf/applications/ert_tui/main.c
+++ b/libenkf/applications/ert_tui/main.c
@@ -158,10 +158,14 @@ int main (int argc , char ** argv) {
     }
     enkf_welcome( model_config_file );
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap(model_config_file , true , true);
+      site_config_type * site_config = site_config_alloc_load_user_config(
+                                                            model_config_file
+                                                            );
+      enkf_main_type * enkf_main = enkf_main_alloc(model_config_file, site_config, true, true);
       enkf_main_run_workflows( enkf_main , workflow_list );
       enkf_tui_main_menu(enkf_main); 
       enkf_main_free(enkf_main);
+      site_config_free(site_config);
     }
 
     stringlist_free( workflow_list );

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -1,7 +1,7 @@
 import time
 from res.job_queue import JobStatusType
 from ert_gui import ERT
-from res.enkf import ErtLog
+from res.util import ResLog
 
 
 class ErtRunError(Exception):


### PR DESCRIPTION
Fixed the following:
- When allocating enkf_main site_config must be provided and
- the log was moved to different python module.