### PR TITLE
adressed MACOSX error

### DIFF
--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -139,7 +139,7 @@ class build_class():
         self.compile_ecl(basedir, install_dir)
 
         from sys import platform
-        if (rep.name == 'libecl' and (platform == 'Darwin' or platform == 'darwin'))
+        if (rep.name == 'libecl' and (platform == 'Darwin' or platform == 'darwin')):
             return
            
         self.compile_res(basedir, install_dir)

--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -139,7 +139,7 @@ class build_class():
             os.makedirs(install_dir)
         self.compile_ecl(basedir, install_dir)
 
-        if (rep.name == 'libecl' and (platform == 'Darwin' or platform == 'darwin')):
+        if (self.rep_name == 'libecl' and (platform == 'Darwin' or platform == 'darwin')):
             return
            
         self.compile_res(basedir, install_dir)

--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -7,6 +7,7 @@ import sys
 import subprocess
 import shutil
 import codecs
+from sys import platform
 
 GITHUB_ROT13_API_TOKEN = "rp2rr795p41n83p076o6ro2qp209981r00590r8q"
 
@@ -138,7 +139,6 @@ class build_class():
             os.makedirs(install_dir)
         self.compile_ecl(basedir, install_dir)
 
-        from sys import platform
         if (rep.name == 'libecl' and (platform == 'Darwin' or platform == 'darwin')):
             return
            

--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -137,6 +137,11 @@ class build_class():
         if not os.path.isdir(install_dir):
             os.makedirs(install_dir)
         self.compile_ecl(basedir, install_dir)
+
+        from sys import platform
+            if (rep.name == 'libecl' and (platform == 'Darwin' or platform == 'darwin'))
+               return
+           
         self.compile_res(basedir, install_dir)
         if self.build_ert:
             self.compile_ert(basedir, install_dir)

--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -139,8 +139,8 @@ class build_class():
         self.compile_ecl(basedir, install_dir)
 
         from sys import platform
-            if (rep.name == 'libecl' and (platform == 'Darwin' or platform == 'darwin'))
-               return
+        if (rep.name == 'libecl' and (platform == 'Darwin' or platform == 'darwin'))
+            return
            
         self.compile_res(basedir, install_dir)
         if self.build_ert:


### PR DESCRIPTION
**Task**
There is a compile error  building res w/ Mac OSX systems. 


**Approach**
Travis python build script will not build and test ert/res from ecl repositories on Mac OsX systems. 


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#
* Statoil/libecl#
