### PR TITLE
Show output from ctest failures.

### DIFF
--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -156,7 +156,7 @@ class build_class():
         subprocess.check_call(cmake_args)
         subprocess.check_call(["make"])
         if test:
-            subprocess.check_call(["ctest"])
+            subprocess.check_call(["ctest", "--output-on-failure"])
         subprocess.check_call(["make" , "install"])
         subprocess.check_call(["bin/test_install"])
         os.chdir(cwd) 


### PR DESCRIPTION
**Task**
Show output from failing tests in travis.


**Approach**
Add `--output-on-failure` option when running ctest.

