### PR TITLE
Correct gui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ add_definitions( -DHAVE_PROC )
 if (BUILD_TESTS)
    option( ERT_LSF_SUBMIT_TEST "Build and run tests of LSF submit" OFF)
 endif()
-add_subdirectory( bin )
+
 
 include(cmake/ert_module_name.cmake)
 
@@ -129,6 +129,7 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/share DESTINATION ${CMAKE_INSTALL_PREFIX
 
 
 add_subdirectory( python )
+add_subdirectory( bin )
 
 if(RST_DOC)
    add_subdirectory( docs )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if (EXISTS ${STATOIL_TESTDATA_ROOT})
   message(STATUS "Linking testdata: ${LINK} -> ${STATOIL_TESTDATA_ROOT}")
 endif()
 
-
+EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/share" "${CMAKE_CURRENT_SOURCE_DIR}/build/share" )
 
 include( CheckFunctionExists )
 include( CheckTypeSize )

--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -167,6 +167,7 @@ class PrBuilder():
 
         cwd = os.getcwd()
         os.chdir(build_dir)
+        subprocess.check_call(["ln", "-s", "../share", "."])
         subprocess.check_call(cmake_args)
         subprocess.check_call(["make"])
         if test:

--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -167,7 +167,6 @@ class PrBuilder():
 
         cwd = os.getcwd()
         os.chdir(build_dir)
-        subprocess.check_call(["ln", "-s", "../share", "."])
         subprocess.check_call(cmake_args)
         subprocess.check_call(["make"])
         if test:


### PR DESCRIPTION
**Task**
During Ert-1284 some problems with running ert arose. 


**Approach**
- Minor change in ert/CMakeLists.txt, allowing for some essential initialization in ert/python before ert/bin, pluss added symlink in build to ert/share. 



**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#
* Statoil/libecl#
