### PR TITLE
Create gui test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ add_definitions( -DHAVE_PROC )
 if (BUILD_TESTS)
    option( ERT_LSF_SUBMIT_TEST "Build and run tests of LSF submit" OFF)
 endif()
-add_subdirectory( bin )
+
 
 include(cmake/ert_module_name.cmake)
 
@@ -129,6 +129,7 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/share DESTINATION ${CMAKE_INSTALL_PREFIX
 
 
 add_subdirectory( python )
+add_subdirectory( bin )
 
 if(RST_DOC)
    add_subdirectory( docs )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,17 +24,19 @@ option( GUI                 "Build Python GUI"                                  
 find_package( ecl REQUIRED )
 find_package( res REQUIRED )
 
+function( make_symlink target link )
+  if (EXISTS ${link}) 
+     EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E remove "${link}")
+  endif()
+  EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${target}" "${link}")
+  message(STATUS "Linking : ${link} -> ${target}")
+endfunction()  
 
 set(STATOIL_TESTDATA_ROOT "" CACHE PATH  "Root to Statoil internal testdata")
 if (EXISTS ${STATOIL_TESTDATA_ROOT})
-  set( LINK "${CMAKE_CURRENT_SOURCE_DIR}/test-data/Statoil" )
-  if (EXISTS ${LINK})
-    EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E remove "${LINK}")
-  endif()
-
-  EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${STATOIL_TESTDATA_ROOT}" "${LINK}")
-  message(STATUS "Linking testdata: ${LINK} -> ${STATOIL_TESTDATA_ROOT}")
+  make_symlink( "${STATOIL_TESTDATA_ROOT}" "${CMAKE_CURRENT_SOURCE_DIR}/test-data/Statoil")
 endif()
+make_symlink( "${CMAKE_CURRENT_SOURCE_DIR}/share" "${CMAKE_CURRENT_BINARY_DIR}/share" )
 
 
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,6 +1,6 @@
 set( ERT_ROOT ${PROJECT_BINARY_DIR})
 configure_file(ert.in  ${EXECUTABLE_OUTPUT_PATH}/ert )
-
+configure_file(gui_test.in ${EXECUTABLE_OUTPUT_PATH}/gui_test)
 
 set( ERT_ROOT ${CMAKE_INSTALL_PREFIX})
 configure_file(ert.in  ${EXECUTABLE_OUTPUT_PATH}/ert_install )

--- a/bin/gui_test.in
+++ b/bin/gui_test.in
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+import sys
+import os
+import subprocess
+from argparse import ArgumentParser
+import inspect
+
+from ecl.test import TestAreaContext
+
+config_file = "${PROJECT_SOURCE_DIR}/test-data/local/snake_oil_no_data/snake_oil.ert"
+ERT_ROOT = "${ERT_ROOT}"
+ERT_LD_LIBRARY_PATH = "%s/${CMAKE_INSTALL_LIBDIR}" % ERT_ROOT
+ERT_PYTHONPATH = "%s/${PYTHON_INSTALL_PREFIX}" % ERT_ROOT
+ERT_SHARE_PATH = "%s/share" % ERT_ROOT
+
+ert = os.path.join( ERT_ROOT , "bin/ert" )
+
+def updateEnvVar(var, value):
+    print "|  * %s=%s" % (var,value)
+    os.environ[var] = value
+
+
+def updateEnvPath(path_var, value):
+    if path_var in os.environ:
+        path = "%s%s%s" % (value, os.pathsep, os.environ[path_var])
+        print "|  * %s=%s:$%s" % (path_var , value , path_var)
+    else:
+        path = value
+        print "|  * %s=$%s" % (path_var , value )
+
+    os.environ[path_var] = path
+
+
+def updateEnv():
+    print "/----------------------------------------------------------------"
+    print "| Setting environment variables for the run:"
+    print "|"
+    updateEnvPath( "LD_LIBRARY_PATH" , ERT_LD_LIBRARY_PATH )
+    updateEnvPath( "PYTHONPATH"      , ERT_PYTHONPATH )
+    updateEnvVar("ERT_SHARE_PATH", ERT_SHARE_PATH)
+    updateEnvVar("ERT_UI_MODE", "gui")
+    print "|"
+    print "\n\----------------------------------------------------------------\n\n"
+
+
+def check_ecl_res():
+    print "/----------------------------------------------------------------"
+    print "| Checking the import of ecl and res packages."
+    print "|"
+    try:
+        import ecl
+    except ImportError:
+        print "| Importing ecl failed completely"
+        sys.exit(1)
+
+    try:
+        import res
+    except ImportError:
+        print "| Importing res failed completely"
+        sys.exit(1)
+
+    ecl_path, _ = os.path.split( inspect.getfile( ecl ))
+    res_path, _ = os.path.split( inspect.getfile( res ))
+
+    print "|  ecl: %s" % ecl_path
+    print "|  res: %s" % res_path
+    print "|"
+    print "| If this does not agree with your expectations you should update"
+    print "| your PYTHONPATH enviornment variable and try again."
+    print "\----------------------------------------------------------------\n\n"
+
+
+def run(config_file, keep, ta = None):
+    print "/----------------------------------------------------------------"
+    print "| Starting the actual run:"
+    print "|"
+
+    cmd_args = [ert, "--gui", config_file]
+    if ta:
+        if keep:
+            print "| Run will be located in: %s" % ta.get_cwd( )
+        else:
+            print "| Run will be in temporary location - rerun with --keep to retain"
+    print "|"
+    print "| Calling ert as:"
+    print "|"
+    print "|      %s" % " ".join( cmd_args )
+    print "|"
+    print "\----------------------------------------------------------------"
+    subprocess.check_call( cmd_args )
+    
+
+
+parser = ArgumentParser( )
+parser.add_argument("--keep" , dest = "keep" , action = "store_true" , default = False,
+                    help="If you pass option --keep the temporary directory used for the test will be retained")
+options, args = parser.parse_known_args( args = sys.argv[1:] )
+
+print
+updateEnv( )
+check_ecl_res( )
+
+if len(args) == 0:
+    with TestAreaContext( "gui_test" , store_area = options.keep ) as ta:
+        ta.copy_parent_content( config_file )
+        run( os.path.basename( config_file ) , options.keep , ta)
+else:
+    # A config file argument has been passed to the script,
+    # we use that config file instead of the in-source testcase.
+    # We do not create a temporary directory in this case.
+    config_file = args[0]
+    run( config_file , True )     
+       


### PR DESCRIPTION
**Task**
Add a small script `build/bin/gui_test` which should be a one-command-no-setup to invoke the gui on a test case.


**Approach**
The idea is that with this script in place you can run:
```bash
cmd> cd build
cmd> make
cmd> bin/gui_test
```
in the ert repository. The `gui_test` script will set some environment variables and then invoke the ert gui properly. Some status information is printed in the console - it is important to read and understand this.

By default the script will invoke ert with this [config file[(https://github.com/Statoil/ert/blob/master/test-data/local/snake_oil_no_data/snake_oil.ert). The actual test will be perfomed in a temporary directory, by default the temporary directory will be deleted afterwards, but if you pass option: `--keep` the folder will be retained e.g. for debugging.

Optionally you can pass an alternative config file as commandline argument:
```
bin/gui_test /path/to/my_config_file
```
in that case the simulation will be performed in-place and no cleanup will be done afterwards.



**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [x] Have completed graphical integration test steps


