### PR TITLE
WIP: Simulation pretest

### DIFF
--- a/python/python/ert_gui/simulation/CMakeLists.txt
+++ b/python/python/ert_gui/simulation/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(PYTHON_SOURCES
     __init__.py
+    single_test_run_panel.py
     ensemble_experiment_panel.py
     ensemble_smoother_panel.py
     iterated_ensemble_smoother_panel.py

--- a/python/python/ert_gui/simulation/__init__.py
+++ b/python/python/ert_gui/simulation/__init__.py
@@ -2,6 +2,7 @@ from .progress import Progress
 from .simple_progress import SimpleProgress
 from .run_dialog import RunDialog
 from .simulation_config_panel import SimulationConfigPanel
+from .single_test_run_panel import SingleTestRunPanel
 from .ensemble_experiment_panel import EnsembleExperimentPanel
 from .ensemble_smoother_panel import EnsembleSmootherPanel
 from .iterated_ensemble_smoother_panel import IteratedEnsembleSmootherPanel

--- a/python/python/ert_gui/simulation/models/CMakeLists.txt
+++ b/python/python/ert_gui/simulation/models/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PYTHON_SOURCES
     __init__.py
     base_run_model.py
+    single_test_run.py
     ensemble_experiment.py
     ensemble_smoother.py
     iterated_ensemble_smoother.py

--- a/python/python/ert_gui/simulation/models/CMakeLists.txt
+++ b/python/python/ert_gui/simulation/models/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(PYTHON_SOURCES
     __init__.py
     base_run_model.py
-    single_test_run.py
     ensemble_experiment.py
+    single_test_run.py
     ensemble_smoother.py
     iterated_ensemble_smoother.py
     multiple_data_assimilation.py

--- a/python/python/ert_gui/simulation/models/__init__.py
+++ b/python/python/ert_gui/simulation/models/__init__.py
@@ -1,6 +1,6 @@
 from .base_run_model import BaseRunModel, ErtRunError
-from .single_test_run import SingleTestRun
 from .ensemble_experiment import EnsembleExperiment
+from .single_test_run import SingleTestRun
 from .ensemble_smoother import EnsembleSmoother
 from .iterated_ensemble_smoother import IteratedEnsembleSmoother
 from .multiple_data_assimilation import MultipleDataAssimilation

--- a/python/python/ert_gui/simulation/models/__init__.py
+++ b/python/python/ert_gui/simulation/models/__init__.py
@@ -1,4 +1,5 @@
 from .base_run_model import BaseRunModel, ErtRunError
+from .single_test_run import SingleTestRun
 from .ensemble_experiment import EnsembleExperiment
 from .ensemble_smoother import EnsembleSmoother
 from .iterated_ensemble_smoother import IteratedEnsembleSmoother

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -25,7 +25,9 @@ class BaseRunModel(object):
         self.__job_queue = None
         self.reset( )
 
-
+    def set_name(self, name):
+        self._name = name
+    
     def ert(self):
         """ @rtype: res.enkf.EnKFMain"""
         return ERT.ert

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -196,7 +196,13 @@ class BaseRunModel(object):
         """ @rtype: bool """
         return not self.isFinished() and self._indeterminate
 
-
+    def assertHaveSufficientRealizations(self, num_successful_realizations, active_realizations):
+        if num_successful_realizations == 0:
+            raise ErtRunError("Simulation failed! All realizations failed!")
+        elif not self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, active_realizations):
+            raise ErtRunError("Too many simulations have failed! You can add/adjust MIN_REALIZATIONS to allow failures in your simulations.\n\n"
+                              "Check ERT log file '%s' or simulation folder for details." % ErtLog.getFilename()) 
+    
     def checkHaveSufficientRealizations(self, num_successful_realizations):
         if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed! All realizations failed!")

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -24,9 +24,6 @@ class BaseRunModel(object):
         self._failed = False
         self.__job_queue = None
         self.reset( )
-
-    def set_name(self, name):
-        self._name = name
     
     def ert(self):
         """ @rtype: res.enkf.EnKFMain"""

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -11,6 +11,11 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhase(0, "Running simulations...", indeterminate=False)
         active_realization_mask = arguments["active_realizations"]
 
+        active_realizations = 0;
+        for b in active_realization_mask:
+           if (b == 1):
+              active_realizations = active_realizations + 1
+
         self.setPhaseName("Pre processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
@@ -19,7 +24,7 @@ class EnsembleExperiment(BaseRunModel):
 
         num_successful_realizations = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(job_queue, active_realization_mask)
 
-        self.checkHaveSufficientRealizations(num_successful_realizations)
+        self.assertHaveSufficientRealizations(num_successful_realizations, active_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -10,11 +10,7 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhase(0, "Running simulations...", indeterminate=False)
         active_realization_mask = arguments["active_realizations"]
 
-        active_realizations = 0;
-        for b in active_realization_mask:
-           if (b == 1):
-              active_realizations = active_realizations + 1
-
+        active_realizations = self.count_active_realizations(active_realization_mask);
 
         self.setPhaseName("Pre processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
@@ -31,5 +27,6 @@ class EnsembleExperiment(BaseRunModel):
 
         self.setPhase(1, "Simulations completed.") # done...
 
-
+    def count_active_realizations(self, active_realization_mask):
+        return sum(active_realization_mask)
 

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -1,7 +1,6 @@
 from res.enkf.enums import HookRuntime
 from ert_gui.simulation.models import BaseRunModel, ErtRunError
 
-
 class EnsembleExperiment(BaseRunModel):
 
     def __init__(self):
@@ -15,6 +14,7 @@ class EnsembleExperiment(BaseRunModel):
         for b in active_realization_mask:
            if (b == 1):
               active_realizations = active_realizations + 1
+
 
         self.setPhaseName("Pre processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)

--- a/python/python/ert_gui/simulation/models/single_test_run.py
+++ b/python/python/ert_gui/simulation/models/single_test_run.py
@@ -7,4 +7,27 @@ class SingleTestRun(BaseRunModel):
         super(SingleTestRun, self).__init__("Single test-run")
 
     def runSimulations(self, job_queue,  arguments):
-        pass
+        self.setPhase(0, "Running simulations...", indeterminate=False)
+        active_realization_mask = arguments["active_realizations"]
+
+        active_realizations = 1;
+        for n in range(1, len(active_realization_mask)):
+            active_realization_mask[n] = False
+
+        active_realization_mask[0] = True;
+
+        self.setPhaseName("Pre processing...", indeterminate=True)
+        self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
+        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
+
+        self.setPhaseName("Running ensemble experiment...", indeterminate=False)
+
+        num_successful_realizations = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(job_queue, active_realization_mask)
+
+        self.assertHaveSufficientRealizations(num_successful_realizations, active_realizations)
+
+        self.setPhaseName("Post processing...", indeterminate=True)
+        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
+
+        self.setPhase(1, "Simulations completed.") # done...
+

--- a/python/python/ert_gui/simulation/models/single_test_run.py
+++ b/python/python/ert_gui/simulation/models/single_test_run.py
@@ -1,33 +1,17 @@
 from res.enkf.enums import HookRuntime
-from ert_gui.simulation.models import BaseRunModel, ErtRunError
+from ert_gui.simulation.models import BaseRunModel, ErtRunError, EnsembleExperiment
 
-class SingleTestRun(BaseRunModel):
+class SingleTestRun(EnsembleExperiment):
     
     def __init__(self):
-        super(SingleTestRun, self).__init__("Single test-run")
+        super(EnsembleExperiment, self).__init__("Single test-run")
 
-    def runSimulations(self, job_queue,  arguments):
-        self.setPhase(0, "Running simulations...", indeterminate=False)
-        active_realization_mask = arguments["active_realizations"]
-
-        active_realizations = 1;
+    def count_active_realizations(self, active_realization_mask):
         for n in range(1, len(active_realization_mask)):
             active_realization_mask[n] = False
 
         active_realization_mask[0] = True;
+        return 1
 
-        self.setPhaseName("Pre processing...", indeterminate=True)
-        self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
-        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
-
-        self.setPhaseName("Running ensemble experiment...", indeterminate=False)
-
-        num_successful_realizations = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(job_queue, active_realization_mask)
-
-        self.assertHaveSufficientRealizations(num_successful_realizations, active_realizations)
-
-        self.setPhaseName("Post processing...", indeterminate=True)
-        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
-
-        self.setPhase(1, "Simulations completed.") # done...
+    
 

--- a/python/python/ert_gui/simulation/models/single_test_run.py
+++ b/python/python/ert_gui/simulation/models/single_test_run.py
@@ -1,0 +1,10 @@
+from res.enkf.enums import HookRuntime
+from ert_gui.simulation.models import BaseRunModel, ErtRunError
+
+class SingleTestRun(BaseRunModel):
+    
+    def __init__(self):
+        super(SingleTestRun, self).__init__("Single test-run")
+
+    def runSimulations(self, job_queue,  arguments):
+        pass

--- a/python/python/ert_gui/simulation/simulation_config_panel.py
+++ b/python/python/ert_gui/simulation/simulation_config_panel.py
@@ -16,6 +16,9 @@ class SimulationConfigPanel(QWidget):
     def is_advanced_option(self):
         return self._advanced_option
 
+    def set_model_name(self, name):
+        self.__simulation_model.set_name(name)
+
     def getSimulationModel(self):
         return self.__simulation_model
 

--- a/python/python/ert_gui/simulation/simulation_config_panel.py
+++ b/python/python/ert_gui/simulation/simulation_config_panel.py
@@ -16,9 +16,6 @@ class SimulationConfigPanel(QWidget):
     def is_advanced_option(self):
         return self._advanced_option
 
-    def set_model_name(self, name):
-        self.__simulation_model.set_name(name)
-
     def getSimulationModel(self):
         return self.__simulation_model
 

--- a/python/python/ert_gui/simulation/simulation_panel.py
+++ b/python/python/ert_gui/simulation/simulation_panel.py
@@ -53,7 +53,7 @@ class SimulationPanel(QWidget):
         self._simulation_widgets = OrderedDict()
         """ :type: OrderedDict[BaseRunModel,SimulationConfigPanel]"""
 
-        #self.addSimulationConfigPanel(SingleTestRunPanel())
+        self.addSimulationConfigPanel(SingleTestRunPanel())
         self.addSimulationConfigPanel(EnsembleExperimentPanel())
         self.addSimulationConfigPanel(EnsembleSmootherPanel())
         self.addSimulationConfigPanel(IteratedEnsembleSmootherPanel(advanced_option=True))

--- a/python/python/ert_gui/simulation/simulation_panel.py
+++ b/python/python/ert_gui/simulation/simulation_panel.py
@@ -5,6 +5,7 @@ from ert_gui import ERT
 from ert_gui.ertwidgets import addHelpToWidget, resourceIcon
 from ert_gui.ertwidgets.models.ertmodel import getCurrentCaseName
 from ert_gui.simulation import EnsembleExperimentPanel, EnsembleSmootherPanel
+from ert_gui.simulation import SingleTestRunPanel
 from ert_gui.simulation import IteratedEnsembleSmootherPanel, MultipleDataAssimilationPanel, SimulationConfigPanel
 from ert_gui.simulation import RunDialog
 from collections import OrderedDict
@@ -52,6 +53,7 @@ class SimulationPanel(QWidget):
         self._simulation_widgets = OrderedDict()
         """ :type: OrderedDict[BaseRunModel,SimulationConfigPanel]"""
 
+        self.addSimulationConfigPanel(SingleTestRunPanel())
         self.addSimulationConfigPanel(EnsembleExperimentPanel())
         self.addSimulationConfigPanel(EnsembleSmootherPanel())
         self.addSimulationConfigPanel(IteratedEnsembleSmootherPanel(advanced_option=True))

--- a/python/python/ert_gui/simulation/simulation_panel.py
+++ b/python/python/ert_gui/simulation/simulation_panel.py
@@ -53,7 +53,7 @@ class SimulationPanel(QWidget):
         self._simulation_widgets = OrderedDict()
         """ :type: OrderedDict[BaseRunModel,SimulationConfigPanel]"""
 
-        self.addSimulationConfigPanel(SingleTestRunPanel())
+        #self.addSimulationConfigPanel(SingleTestRunPanel())
         self.addSimulationConfigPanel(EnsembleExperimentPanel())
         self.addSimulationConfigPanel(EnsembleSmootherPanel())
         self.addSimulationConfigPanel(IteratedEnsembleSmootherPanel(advanced_option=True))

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -24,26 +24,12 @@ class SingleTestRunPanel(SimulationConfigPanel):
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)
 
-        number_of_realizations_label = QLabel("<b>%d</b>" % 1)
-        addHelpToWidget(number_of_realizations_label, "config/ensemble/num_realizations")
-        layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
-
         self._active_realizations_model = ActiveRealizationsModel()
-        self._active_realizations_field = StringBox(self._active_realizations_model, "config/simulation/active_realizations")
-        self._active_realizations_field.setValidator(RangeStringArgument(getRealizationCount()))
-        layout.addRow("Active realizations", self._active_realizations_field)
-
-        self._active_realizations_field.getValidationSupport().validationChanged.connect(self.simulationConfigurationChanged)
 
         self.setLayout(layout)
 
-
-    def isConfigurationValid(self):
-        return self._active_realizations_field.isValid()
-
     def toggleAdvancedOptions(self, show_advanced):
-        self._active_realizations_field.setVisible(False)
-        self.layout().labelForField(self._active_realizations_field).setVisible(False)
+        pass
 
     def getSimulationArguments(self):
         active_realizations_mask = self._active_realizations_model.getActiveRealizationsMask()

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -13,7 +13,9 @@ from ert_gui.simulation.simulation_config_panel import SimulationConfigPanel
 class SingleTestRunPanel(SimulationConfigPanel):
 
     def __init__(self):
-        SimulationConfigPanel.__init__(self, SingleTestRun())
+        SimulationConfigPanel.__init__(self, EnsembleExperiment())
+        self.set_model_name('Single testrun')
+        
 
     def toggleAdvancedOptions(self, show_advanced):
         pass

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -16,6 +16,38 @@ class SingleTestRunPanel(SimulationConfigPanel):
         SimulationConfigPanel.__init__(self, EnsembleExperiment())
         self.set_model_name('Single testrun')
         
+        layout = QFormLayout()
+
+        case_selector = CaseSelector()
+        layout.addRow("Current case:", case_selector)
+
+        run_path_label = QLabel("<b>%s</b>" % getRunPath())
+        addHelpToWidget(run_path_label, "config/simulation/runpath")
+        layout.addRow("Runpath:", run_path_label)
+
+        number_of_realizations_label = QLabel("<b>%d</b>" % getRealizationCount())
+        addHelpToWidget(number_of_realizations_label, "config/ensemble/num_realizations")
+        layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
+
+        self._active_realizations_model = ActiveRealizationsModel()
+        self._active_realizations_field = StringBox(self._active_realizations_model, "config/simulation/active_realizations")
+        self._active_realizations_field.setValidator(RangeStringArgument(getRealizationCount()))
+        layout.addRow("Active realizations", self._active_realizations_field)
+
+        self._active_realizations_field.getValidationSupport().validationChanged.connect(self.simulationConfigurationChanged)
+
+        self.setLayout(layout)
+
+
+    def isConfigurationValid(self):
+        return self._active_realizations_field.isValid()
 
     def toggleAdvancedOptions(self, show_advanced):
-        pass
+        self._active_realizations_field.setVisible(show_advanced)
+        self.layout().labelForField(self._active_realizations_field).setVisible(show_advanced)
+
+    def getSimulationArguments(self):
+        active_realizations_mask = self._active_realizations_model.getActiveRealizationsMask()
+        return {"active_realizations": active_realizations_mask}
+
+

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -1,0 +1,19 @@
+from PyQt4.QtGui import QFormLayout, QLabel
+
+from ert_gui.ertwidgets import addHelpToWidget
+from ert_gui.ertwidgets.caseselector import CaseSelector
+from ert_gui.ertwidgets.models.activerealizationsmodel import ActiveRealizationsModel
+from ert_gui.ertwidgets.models.ertmodel import getRealizationCount, getRunPath
+from ert_gui.ertwidgets.stringbox import StringBox
+from ert_gui.ide.keywords.definitions import RangeStringArgument
+from ert_gui.simulation.models import EnsembleExperiment
+from ert_gui.simulation.models import SingleTestRun
+from ert_gui.simulation.simulation_config_panel import SimulationConfigPanel
+
+class SingleTestRunPanel(SimulationConfigPanel):
+
+    def __init__(self):
+        SimulationConfigPanel.__init__(self, SingleTestRun())
+
+    def toggleAdvancedOptions(self, show_advanced):
+        pass

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -13,8 +13,7 @@ from ert_gui.simulation.simulation_config_panel import SimulationConfigPanel
 class SingleTestRunPanel(SimulationConfigPanel):
 
     def __init__(self):
-        SimulationConfigPanel.__init__(self, EnsembleExperiment())
-        self.set_model_name('Single testrun')
+        SimulationConfigPanel.__init__(self, SingleTestRun())
         
         layout = QFormLayout()
 
@@ -25,7 +24,7 @@ class SingleTestRunPanel(SimulationConfigPanel):
         addHelpToWidget(run_path_label, "config/simulation/runpath")
         layout.addRow("Runpath:", run_path_label)
 
-        number_of_realizations_label = QLabel("<b>%d</b>" % getRealizationCount())
+        number_of_realizations_label = QLabel("<b>%d</b>" % 1)
         addHelpToWidget(number_of_realizations_label, "config/ensemble/num_realizations")
         layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
 
@@ -43,8 +42,8 @@ class SingleTestRunPanel(SimulationConfigPanel):
         return self._active_realizations_field.isValid()
 
     def toggleAdvancedOptions(self, show_advanced):
-        self._active_realizations_field.setVisible(show_advanced)
-        self.layout().labelForField(self._active_realizations_field).setVisible(show_advanced)
+        self._active_realizations_field.setVisible(False)
+        self.layout().labelForField(self._active_realizations_field).setVisible(False)
 
     def getSimulationArguments(self):
         active_realizations_mask = self._active_realizations_model.getActiveRealizationsMask()


### PR DESCRIPTION
**Task**
As part of ERT-1284, a feature (choice in drop down panel)has been added to ert_gui making it possible to start only a single testrun. 


**Approach**
Two new objects of type of type base_run_model and simulation_config_panel has been added, called single_test_run and single_test_run_panel. single_test_run functions much like ensemble_experiment, except that the argument part is overwritten before the testruns are started. 


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [x] Have completed graphical integration test steps

