### PR TITLE
Pandas drops duplicates

### DIFF
--- a/python/python/ert_gui/plottery/plot_data_gatherer.py
+++ b/python/python/ert_gui/plottery/plot_data_gatherer.py
@@ -71,6 +71,7 @@ class PlotDataGatherer(object):
         data = SummaryCollector.loadAllSummaryData(ert, case, [key])
         if not data.empty:
             data = data.reset_index()
+            data = data.drop_duplicates()
             data = data.pivot(index="Date", columns="Realization", values=key)
 
         return data #.dropna()


### PR DESCRIPTION
**Task**
_ERT makes pandy cry heavily if duplicate entries appear._


**Approach**
_Remove duplicates before visualization. Note that the underlying data is not touched._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
