### PR TITLE
Make sure env variable ERT_ROOT is set.

### DIFF
--- a/bin/ert.in
+++ b/bin/ert.in
@@ -65,7 +65,7 @@ updateEnvPath( "LD_LIBRARY_PATH" , ERT_LD_LIBRARY_PATH )
 updateEnvPath( "PYTHONPATH"      , ERT_PYTHONPATH )
 os.environ["ERT_SHARE_PATH"] = ERT_SHARE_PATH
 os.environ["ERT_UI_MODE"] = "gui"
-
+os.environ["ERT_ROOT"] = ERT_ROOT
 
 parser = ArgumentParser( )
 mode = parser.add_mutually_exclusive_group( required = False )


### PR DESCRIPTION
**Task**
The env variable $ERT_ROOT must be set to find config elements located in $ERT_ROOT/..


**Approach**
Call os.environ["ERT_ROOT"] =  


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
