### PR TITLE
Print warning if duplicate timestamps

### DIFF
--- a/python/python/ert_gui/plottery/plot_data_gatherer.py
+++ b/python/python/ert_gui/plottery/plot_data_gatherer.py
@@ -71,7 +71,13 @@ class PlotDataGatherer(object):
         data = SummaryCollector.loadAllSummaryData(ert, case, [key])
         if not data.empty:
             data = data.reset_index()
-            data = data.drop_duplicates()
+
+            if True in data.duplicated():
+              print("** Warning: The simulation data contains duplicate "
+                    "timestamps. A possible explanation is that your "
+                    "simulation timestep is less than a second.")
+              data = data.drop_duplicates()
+
             data = data.pivot(index="Date", columns="Realization", values=key)
 
         return data #.dropna()


### PR DESCRIPTION
**Task**
_Minor extension of the following PR: https://github.com/Statoil/ert/pull/34._


**Approach**
_Print a warning in the case of duplicate timestamps and refer the user to the simulation timestep. As although ERT now handles duplicates, it was probably not what the user had in mind when running their simulations._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
