### PR TITLE
Added file job_dispatch.py symlink - only for testing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,12 @@ set(STATOIL_TESTDATA_ROOT "" CACHE PATH  "Root to Statoil internal testdata")
 if (EXISTS ${STATOIL_TESTDATA_ROOT})
   make_symlink( "${STATOIL_TESTDATA_ROOT}" "${CMAKE_CURRENT_SOURCE_DIR}/test-data/Statoil")
 endif()
-make_symlink( "${CMAKE_CURRENT_SOURCE_DIR}/share" "${CMAKE_CURRENT_BINARY_DIR}/share" )
 
+EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/bin")
+make_symlink( "${CMAKE_CURRENT_SOURCE_DIR}/share" "${CMAKE_CURRENT_BINARY_DIR}/share" )
+make_symlink( "${res_DIR}/bin/job_dispatch.py" "${CMAKE_CURRENT_BINARY_DIR}/bin/job_dispatch.py")
+
+set( ERT_ROOT "${PROJECT_BINARY_DIR}" )
 
 
 include( CheckFunctionExists )


### PR DESCRIPTION
**Task**
This "fix" is *purely* to get the tests through. Some tests require a valid site configuration file which among other things expect to find a job_dispatch script in `$ERT_ROOT/bin/job_dispatch.py`. The real job_dispatch.py script is in libres - this symlink is purely for testing.


**Approach**
Configure cmake to create symlnk


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

