### PR TITLE
Correct link target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/bin")
 make_symlink( "${CMAKE_CURRENT_SOURCE_DIR}/share" "${CMAKE_CURRENT_BINARY_DIR}/share" )
-make_symlink( "${res_DIR}/bin/job_dispatch.py" "${PROJECT_BINARY_DIR}/bin/job_dispatch.py")
+make_symlink( "${res_DIR}/../../bin/job_dispatch.py" "${PROJECT_BINARY_DIR}/bin/job_dispatch.py")
 
 set( ERT_ROOT "${PROJECT_BINARY_DIR}" )
 


### PR DESCRIPTION
**Task**
Deploy


**Approach**
cmake variable `${res_DIR}` points into the `share/` hierarchy - `../../` to get out.

:cowboy_hat_face: :cowboy_hat_face: 