### PR TITLE
Link to the correct job_dispatch from libres.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,9 @@ function( make_symlink target link )
   endif()
 
   if (EXISTS ${target})
-     EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${target}" "${link}")
-     message(STATUS "Linking : ${link} -> ${target}")
+     get_filename_component( abs_target ${target} ABSOLUTE )
+     EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${abs_target}" "${link}")
+     message(STATUS "Linking : ${link} -> ${abs_target}")
   else()
      message( SEND_ERROR "Link target: ${target} does not exist")
   endif()    
@@ -44,7 +45,7 @@ endif()
 
 EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/bin")
 make_symlink( "${CMAKE_CURRENT_SOURCE_DIR}/share" "${CMAKE_CURRENT_BINARY_DIR}/share" )
-make_symlink( "${res_DIR}/../../bin/job_dispatch.py" "${PROJECT_BINARY_DIR}/bin/job_dispatch.py")
+make_symlink( "${res_DIR}/../../../bin/job_dispatch.py" "${PROJECT_BINARY_DIR}/bin/job_dispatch.py")
 
 set( ERT_ROOT "${PROJECT_BINARY_DIR}" )
 


### PR DESCRIPTION
**Task**
The cmake setup created a symlink to the job_dispatch.py script from libres. Unfortunately there were *two* versions of the job_dispatch script in libres - and the symlink pointed to the wrong version!


**Approach**
Fixed link + using normalized absolute path when linking. 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#63

