### PR TITLE
Fix kill simulations

### DIFF
--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -221,14 +221,14 @@ class BaseRunModel(object):
             raise ErtRunError("Simulation failed! All realizations failed!")
         elif not self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, active_realizations):
             raise ErtRunError("Too many simulations have failed! You can add/adjust MIN_REALIZATIONS to allow failures in your simulations.\n\n"
-                              "Check ERT log file '%s' or simulation folder for details." % ErtLog.getFilename()) 
+                              "Check ERT log file '%s' or simulation folder for details." % ResLog.getFilename()) 
     
     def checkHaveSufficientRealizations(self, num_successful_realizations):
         if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed! All realizations failed!")
         elif not self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, self.ert().getEnsembleSize()):
             raise ErtRunError("Too many simulations have failed! You can add/adjust MIN_REALIZATIONS to allow failures in your simulations.\n\n"
-                              "Check ERT log file '%s' or simulation folder for details." % ErtLog.getFilename())
+                              "Check ERT log file '%s' or simulation folder for details." % ResLog.getFilename())
 
     def checkMinimumActiveRealizations(self, run_context):
         active_realizations = self.count_active_realizations( run_context )


### PR DESCRIPTION
**Task**
While running gui_test: Select "ensemble experiment" or "ensemble smoother", select run and yes, then wait 15 s, then use the kill_simulations button. The program will not actually stop simulations,. 


**Approach**
Use of ErtLog in base_run_model is replaced with ResLog. 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps


