### PR TITLE
Changed to use EclVersion

### DIFF
--- a/python/python/ert_gui/gert_main.py
+++ b/python/python/ert_gui/gert_main.py
@@ -119,7 +119,7 @@ from PyQt4.QtGui import QApplication, QFileDialog
 
 import ert_gui.ertwidgets
 from res.enkf import EnKFMain, ResConfig
-from ecl.util import Version
+from ecl import EclVersion
 from ert_gui.ert_splash import ErtSplash
 from ert_gui.ertwidgets import SummaryPanel, resourceIcon
 from ert_gui.main_window import GertMainWindow
@@ -206,8 +206,9 @@ def main(argv):
         sys.exit(1)
 
     splash = ErtSplash()
-    splash.version = "Version %s" % Version.getVersion()
-    splash.timestamp = Version.getBuildTime()
+    version = EclVersion( )
+    splash.version = "Version %s" % version.versionString()
+    splash.timestamp = version.getBuildTime()
 
     splash.show()
     splash.repaint()

--- a/python/python/ert_gui/shell/debug.py
+++ b/python/python/ert_gui/shell/debug.py
@@ -1,4 +1,4 @@
-from ecl import Version
+from ecl import EclVersion
 from ert_gui.shell import assertConfigLoaded, ErtShellCollection
 
 
@@ -17,6 +17,7 @@ class Debug(ErtShellCollection):
         self.shellContext()["debug"] = self
         self.__last_plugin_result = None
         self.__local_variables = {}
+        self.__version = EclVersion( )
 
     def setLastPluginResult(self, result):
         self.__last_plugin_result = result
@@ -26,20 +27,20 @@ class Debug(ErtShellCollection):
         print("Site Config: %s" % self.ert().siteConfig().getLocation())
 
     def version(self, line):
-        print("Version: %s" % Version.getVersion())
+        print("Version: %s" % self.__version.versionString())
 
     def timestamp(self, line):
-        print("Timestamp: %s" % Version.getBuildTime())
+        print("Timestamp: %s" % self.__version.getBuildTime())
 
     def gitCommit(self, line):
-        print("Git Commit: %s" % Version.getGitCommit(True))
+        print("Git Commit: %s" % self.__version.getGitCommit(True))
 
     @assertConfigLoaded
     def info(self, line):
         print("Site Config: %s" % self.ert().siteConfig().getLocation())
-        print("Version:     %s" % Version.getVersion())
-        print("Timestamp:   %s" % Version.getBuildTime())
-        print("Git Commit:  %s" % Version.getGitCommit(True))
+        print("Version:     %s" % self.__version.versionString())
+        print("Timestamp:   %s" % self.__version.getBuildTime())
+        print("Git Commit:  %s" % self.__version.getGitCommit(True))
 
     def lastPluginResult(self, line):
         print("Last plugin result: %s" % self.__last_plugin_result)


### PR DESCRIPTION
**Task**
See: https://github.com/Statoil/libecl/pull/160

**Approach**
(Temporary) changed from `ecl.version.Version` to `ecl.versionEclVersion`

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#92
* Statoil/libecl#160
