### PR TITLE
Remove last trails of Python 3 from build_total

### DIFF
--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -12,7 +12,7 @@ import requests
 
 GITHUB_ROT13_API_TOKEN = "rp2rr795p41n83p076o6ro2qp209981r00590r8q"
 
-def find_python_version():
+def print_python_version():
     print(sys.version)
 
 def call(args):
@@ -95,12 +95,6 @@ class PrBuilder(object):
         res_word = "Statoil/libres#(\\d+)"
         ert_word = "Statoil/ert#(\\d+)"
         desc = self.pr_description
-  
-        if (sys.version_info.major >= 3):
-            match = re.search('PYTHON3', desc)
-            if not match:
-                print("ERT does not support python version 3 or higher, exiting...")
-                sys.exit(0)
 
         match = re.search(ecl_word, desc, re.MULTILINE)
         if match:
@@ -235,7 +229,7 @@ def main():
     print('\n===================')
     print(' '.join(sys.argv))
     print('===================\n')
-    find_python_version()
+    print_python_version()
     pr_build = PrBuilder(sys.argv)
     pr_build.clone_fetch_merge(basedir)
     pr_build.compile_and_build(basedir)


### PR DESCRIPTION
**Task**
_As of now, build_total does an early exit if Python 3 is detected. This is a problem for the `.travis.yml` to handle. Hence, I'm completely removing this functionality._
