### PR TITLE
Import from res and not from ert

### DIFF
--- a/python/python/bin/ert_tcp_server
+++ b/python/python/bin/ert_tcp_server
@@ -3,7 +3,7 @@ import argparse
 import socket
 import sys
 
-from ert.server.ertrpcserver import ErtRPCServer
+from res.server.ertrpcserver import ErtRPCServer
 
 default_port = 0
 
@@ -51,3 +51,4 @@ except KeyboardInterrupt:
     except Exception as e:
         print("Unable to stop server 'gracefully'!")
         raise e
+


### PR DESCRIPTION
**Task**
_Short description of the task_
The ert_tcp_server is still importing from ert. It needs to import from res. 
At TNO we do not have WPRO so we are still manually starting the server though ert_tcp_server script. I am not sure whether anybody else is using this script so it might not be that important, but today I have reinstalled ert on a cluster and got into this issue and thought to help.

**Approach**
_Short description of the approach_
Small change import from res.server and not from ert.server.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#
* Statoil/libecl#
