### PR TITLE
Remove false warning from duplicated data.

### DIFF
--- a/python/python/ert_gui/plottery/plot_data_gatherer.py
+++ b/python/python/ert_gui/plottery/plot_data_gatherer.py
@@ -72,11 +72,12 @@ class PlotDataGatherer(object):
         if not data.empty:
             data = data.reset_index()
 
-            if True in data.duplicated():
-              print("** Warning: The simulation data contains duplicate "
-                    "timestamps. A possible explanation is that your "
-                    "simulation timestep is less than a second.")
-              data = data.drop_duplicates()
+            if any(data.dupliated()):
+                print("** Warning: The simulation data contains duplicate "
+                      "timestamps. A possible explanation is that your "
+                      "simulation timestep is less than a second.")
+                data = data.drop_duplicates()
+
 
             data = data.pivot(index="Date", columns="Realization", values=key)
 


### PR DESCRIPTION
**Task**
Code produced false warnings of duplicated data when plotting. Do *not* understand what was wrong with the existing code, but this at least removes the false warning. 

Will backport this to stable.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

