### PR TITLE
Using -DENABLE_PYTHON=ON when building libecl + libres.

### DIFF
--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -31,7 +31,7 @@ def build(source_dir, install_dir, test, c_flags="", test_flags=None):
     cmake_args = ["cmake",
                   source_dir,
                   "-DBUILD_TESTS=ON",
-                  "-DBUILD_PYTHON=ON",
+                  "-DENABLE_PYTHON=ON",
                   "-DERT_BUILD_CXX=ON",
                   "-DINSTALL_CWRAP=OFF",
                   "-DBUILD_APPLICATIONS=ON",


### PR DESCRIPTION
**Task**
Small step towards `pip install libecl`




**Depends on**
* Statoil/libres#195
* Statoil/libecl#265
