### PR TITLE
WIP: ecl.test moved to ecl.util.test: changed import statements to comply.

### DIFF
--- a/bin/gui_test.in
+++ b/bin/gui_test.in
@@ -5,7 +5,7 @@ import subprocess
 from argparse import ArgumentParser
 import inspect
 
-from ecl.test import TestAreaContext
+from ecl.util.test import TestAreaContext
 
 config_file = "${PROJECT_SOURCE_DIR}/test-data/local/snake_oil_no_data/snake_oil.ert"
 ERT_ROOT = "${ERT_ROOT}"

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,5 +1,5 @@
 import os.path
-from ecl.test import ExtendedTestCase
+from ecl.util.test import ExtendedTestCase
 
 
 def source_root():

--- a/python/tests/global/test_import_gui.py
+++ b/python/tests/global/test_import_gui.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 
-from ecl.test import ImportTestCase
+from ecl.util.test import ImportTestCase
 
 class ImportGUI(ImportTestCase):
 

--- a/python/tests/global/test_import_plugins.py
+++ b/python/tests/global/test_import_plugins.py
@@ -17,7 +17,7 @@ import os
 import sys
 import glob
 
-from ecl.test import ImportTestCase
+from ecl.util.test import ImportTestCase
 
 class ImportPlugins(ImportTestCase):
 

--- a/python/tests/gui/ertshell/ert_shell_test_context.py
+++ b/python/tests/gui/ertshell/ert_shell_test_context.py
@@ -4,7 +4,7 @@ except ImportError:
     from io import StringIO
 import os
 import sys
-from ecl.test import TestAreaContext
+from ecl.util.test import TestAreaContext
 from ert_gui.shell import ErtShell
 
 class ShellCapturing(list):

--- a/test-data/local/snake_oil_no_data/jobs/snake_oil_simulator.py
+++ b/test-data/local/snake_oil_no_data/jobs/snake_oil_simulator.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from ecl.summary import EclSum, EclSumTStep
-from ecl.test import ExtendedTestCase
+from ecl.util.test import ExtendedTestCase
 print sys.path
 print os.environ["PYTHONPATH"]
 import res


### PR DESCRIPTION
**Task**
As part of libecl issue no. 27, test is moved to ecl.util.test.


**Approach**
As part of libecl issue no. 27, test is moved to ecl.util.test.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#235
* Statoil/libecl#316
