### PR TITLE
new subpackage ecl.util.util: changed import statements to comply.

### DIFF
--- a/python/python/ert_gui/ert_version.py.in
+++ b/python/python/ert_gui/ert_version.py.in
@@ -1,4 +1,4 @@
-from ecl.util import Version,EclVersion
+from ecl.util.util import Version,EclVersion
 from res.util import ResVersion
 
 class ErtVersion(Version):

--- a/python/python/ert_gui/ertplot.py
+++ b/python/python/ert_gui/ertplot.py
@@ -4,7 +4,7 @@ import os
 from PyQt4.QtGui import QApplication
 import time
 from res.enkf import EnKFMain, ResConfig
-from ecl.util import Version
+from ecl.util.util import Version
 from ert_gui.ert_splash import ErtSplash
 from ert_gui.ertwidgets import resourceIcon
 from ert_gui.tools.plot.plot_window import PlotWindow

--- a/python/python/ert_gui/ertwidgets/models/activerealizationsmodel.py
+++ b/python/python/ert_gui/ertwidgets/models/activerealizationsmodel.py
@@ -1,4 +1,4 @@
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from ert_gui.ertwidgets.models.valuemodel import ValueModel
 from ert_gui.ertwidgets.models.ertmodel import getRealizationCount
 

--- a/python/python/ert_gui/ertwidgets/models/ertmodel.py
+++ b/python/python/ert_gui/ertwidgets/models/ertmodel.py
@@ -2,7 +2,7 @@ from res.analysis.analysis_module import AnalysisModule
 from res.analysis.enums.analysis_module_options_enum import AnalysisModuleOptionsEnum
 from res.enkf import RealizationStateEnum, EnkfVarType
 from res.job_queue import WorkflowRunner
-from ecl.util import BoolVector, StringList
+from ecl.util.util import BoolVector, StringList
 from ert_gui import ERT
 from ert_gui.ertwidgets import showWaitCursorWhileWaiting
 

--- a/python/python/ert_gui/gert_main.py
+++ b/python/python/ert_gui/gert_main.py
@@ -118,7 +118,7 @@ from PyQt4.QtCore import Qt
 from PyQt4.QtGui import QApplication, QFileDialog
 
 import ert_gui.ertwidgets
-from ecl.util import EclVersion
+from ecl.util.util import EclVersion
 from res.util import ResVersion
 from res.enkf import EnKFMain, ResConfig
 from res.util import ResLog

--- a/python/python/ert_gui/shell/export.py
+++ b/python/python/ert_gui/shell/export.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from ecl.util import IntVector
+from ecl.util.util import IntVector
 from res.enkf.enums import ErtImplType
 from res.enkf.data import EnkfNode
 from ert_gui.shell import assertConfigLoaded, ErtShellCollection

--- a/python/python/ert_gui/shell/results.py
+++ b/python/python/ert_gui/shell/results.py
@@ -1,4 +1,4 @@
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from ert_gui.shell import assertConfigLoaded, ErtShellCollection
 from ert_gui.shell.libshell import splitArguments
 

--- a/python/python/ert_gui/shell/smoother.py
+++ b/python/python/ert_gui/shell/smoother.py
@@ -1,4 +1,4 @@
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.enkf import ESUpdate, ErtRunContext
 from ert_gui.shell import assertConfigLoaded, ErtShellCollection

--- a/python/python/ert_gui/simulation/models/single_test_run.py
+++ b/python/python/ert_gui/simulation/models/single_test_run.py
@@ -1,4 +1,4 @@
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.enkf.enums import HookRuntime
 from res.enkf import ErtRunContext
 from ert_gui.simulation.models import BaseRunModel, ErtRunError, EnsembleExperiment

--- a/share/workflows/jobs/internal-gui/scripts/export_misfit_data.py
+++ b/share/workflows/jobs/internal-gui/scripts/export_misfit_data.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import os
 from res.enkf import ErtScript, RealizationStateEnum
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 """
 This job exports misfit data into a chosen file or to the default gen_kw export file (parameters.txt)


### PR DESCRIPTION
**Task**
As part of the task concerning libecl issue no. 27, a new subpackage ecl.util.util has been created into which the functional files from ecl.util has been moved.


**Approach**
Import statements changed to comply.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#237
* Statoil/libecl#324
