### PR TITLE
Removed unused references to thread_pool

### DIFF
--- a/libert/applications/ert_tui/enkf_tui_analysis.c
+++ b/libert/applications/ert_tui/enkf_tui_analysis.c
@@ -23,7 +23,6 @@
 #include <ctype.h>
 
 #include <ert/util/util.h>
-#include <ert/util/thread_pool.h>
 #include <ert/util/arg_pack.h>
 #include <ert/util/stringlist.h>
 

--- a/libert/applications/ert_tui/enkf_tui_run.c
+++ b/libert/applications/ert_tui/enkf_tui_run.c
@@ -23,7 +23,6 @@
 #include <ctype.h>
 
 #include <ert/util/util.h>
-#include <ert/util/thread_pool.h>
 #include <ert/util/arg_pack.h>
 #include <ert/util/bool_vector.h>
 #include <ert/util/string_util.h>

--- a/libert/applications/ert_tui/enkf_tui_workflow.c
+++ b/libert/applications/ert_tui/enkf_tui_workflow.c
@@ -23,7 +23,6 @@
 #include <ctype.h>
 
 #include <ert/util/util.h>
-#include <ert/util/thread_pool.h>
 #include <ert/util/arg_pack.h>
 #include <ert/util/bool_vector.h>
 


### PR DESCRIPTION
To be able to move thread_pool implementation from libecl to libres.