### PR TITLE
Ert will not build in python 3

### DIFF
--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -75,6 +75,8 @@ class PrBuilder(object):
         if rep == 'ert':
             self.rep_name = 'ert'
 
+        if sys.version_info[0] > 2:
+            self.build_ert = False
         self.pr_map = {}
         self.access_pr()
         self.test_flags = argv[2:]  # argv = [exec, repo, [L|LE, LABEL]]


### PR DESCRIPTION
**Task**
Move python3 tests in libecl and libres out of "allow failures". This necessitates cancel of building ert in python 3. 


**Approach**
self.build_ert set to false if python3.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libres#
* Statoil/libecl#
