### PR TITLE
TRAVIS: CXX warnings not allowed.

### DIFF
--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -39,6 +39,8 @@ def build(source_dir, install_dir, test, c_flags="", test_flags=None):
                   "-DINSTALL_ERT_LEGACY=ON",
                   "-DCMAKE_PREFIX_PATH=%s" % install_dir,
                   "-DCMAKE_MODULE_PATH=%s/share/cmake/Modules" % install_dir,
+                  "-DERT_USE_OPENMP=ON",
+                  "-DCMAKE_CXX_FLAGS=-Werror",
                   "-DCMAKE_C_FLAGS=%s" % c_flags
                  ]
 

--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -40,7 +40,7 @@ def build(source_dir, install_dir, test, c_flags="", test_flags=None):
                   "-DCMAKE_PREFIX_PATH=%s" % install_dir,
                   "-DCMAKE_MODULE_PATH=%s/share/cmake/Modules" % install_dir,
                   "-DERT_USE_OPENMP=ON",
-                  "-DCMAKE_CXX_FLAGS=-Werror",
+                  "-DCMAKE_CXX_FLAGS=-Werror -Wno-unused-result",
                   "-DCMAKE_C_FLAGS=%s" % c_flags
                  ]
 


### PR DESCRIPTION
**Task**
Compiling of c++ files shall terminate on warnings. 


**Approach**
In build_total.py, for cmake:
-DERT_USE_OPENMP=ON
-DCMAKE_CXX_FLAGS=-Werror


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#408
