### PR TITLE
Qt debug

### DIFF
--- a/python/python/ert_gui/tools/plot/plot_case_model.py
+++ b/python/python/ert_gui/tools/plot/plot_case_model.py
@@ -16,7 +16,7 @@ class PlotCaseModel(QAbstractItemModel):
         self.__data = None
 
     def index(self, row, column, parent=None, *args, **kwargs):
-        return self.createIndex(row, column, parent)
+        return self.createIndex(row, column)
 
     def parent(self, index=None):
         return QModelIndex()


### PR DESCRIPTION
*Background:* In the current master version of ert the testing model used by the FMU team fails when we bring up the window. The failure comes with the error message:

```
ASSERT failure in QAbstractItemView::setModel: "A model should return the exact same index (including its internal id/pointer) when asked for it twice in a row.", file itemviews/qabstractitemview.cpp, line 667
```

After a significant amount of `print()` based debugging the error seems to be here: [ert_gui/tools/plot/plot_case_model.py:19](https://github.com/Statoil/ert/blob/master/python/python/ert_gui/tools/plot/plot_case_model.py#L19) In the first commit of this PR is debug message which prints:

```
PlotCaseModel::index(<ert_gui.tools.plot.plot_case_model.PlotCaseModel object at 0x7f48ac12adf8>,0,0,<PyQt4.QtCore.QModelIndex object at 0x7f48b402caa0>)
PlotCaseModel::index(<ert_gui.tools.plot.plot_case_model.PlotCaseModel object at 0x7f48ac12adf8>,0,0,<PyQt4.QtCore.QModelIndex object at 0x7f48b402cb90>)
ASSERT failure in QAbstractItemView::setModel: "A model should return the exact same index (including its internal id/pointer) when asked for it twice in a row.", file itemviews/qabstractitemview.cpp, line 667
```

i.e. we can see that the `parent` argument is different on the two calls. In the second commit the debug message is removed again, and `None` is passed as parent argument to the `createIndex()` method. It seems to work. The bug is quite evasive:

1. When running with the `snake_oil` testdata set it does not appear.
2. When running on my personal RH7 laptop it does not appear on the FMU tutoral case.

However when running the FMU tutorial case on an RGS workstation the problem appears consistently.
