### PR TITLE
Restart failed realizations

### DIFF
--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -22,6 +22,8 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhaseName( run_msg, indeterminate=False)
 
         num_successful_realizations = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(self._job_queue, run_context)
+
+        num_successful_realizations += arguments['prev_successful_realizations']
         self.checkHaveSufficientRealizations(num_successful_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -9,8 +9,10 @@ class EnsembleExperiment(BaseRunModel):
         super(EnsembleExperiment, self).__init__("Ensemble Experiment" , queue_config)
 
     def runSimulations__(self, arguments, run_msg):
+
         self._job_queue = self._queue_config.create_job_queue( )
         run_context = self.create_context( arguments )
+
         self.setPhase(0, "Running simulations...", indeterminate=False)
 
         self.setPhaseName("Pre processing...", indeterminate=True)
@@ -27,9 +29,11 @@ class EnsembleExperiment(BaseRunModel):
         self.setPhase(1, "Simulations completed.") # done...
         self._job_queue = None
 
+        return run_context
+
 
     def runSimulations(self, arguments ):
-        self.runSimulations__(  arguments , "Running ensemble experiment...")
+        return self.runSimulations__(  arguments , "Running ensemble experiment...")
 
 
     def create_context(self, arguments):

--- a/python/python/ert_gui/simulation/models/ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/ensemble_smoother.py
@@ -9,6 +9,7 @@ class EnsembleSmoother(BaseRunModel):
 
     def __init__(self, queue_config):
         super(EnsembleSmoother, self).__init__("Ensemble Smoother", queue_config , phase_count=2)
+        self.support_restart = False
 
     def setAnalysisModule(self, module_name):
         module_load_success = self.ert().analysisConfig().selectModule(module_name)

--- a/python/python/ert_gui/simulation/models/ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/ensemble_smoother.py
@@ -69,8 +69,11 @@ class EnsembleSmoother(BaseRunModel):
         self.setPhase(2, "Simulations completed.")
         self.__job_queue = None
 
+        return prior_context
+
 
     def create_context(self, arguments, prior_context = None):
+
         model_config = self.ert().getModelConfig( )
         runpath_fmt = model_config.getRunpathFormat( )
         jobname_fmt = model_config.getJobnameFormat( )

--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -66,10 +66,10 @@ class IteratedEnsembleSmoother(BaseRunModel):
         analysis_module = self.setAnalysisModule(arguments["analysis_module"])
         target_case_format = arguments["target_case"]
         run_context = self.create_context( arguments , 0 )
+
         self.ert().analysisConfig().getAnalysisIterConfig().setCaseFormat( target_case_format )
 
         self._runAndPostProcess( run_context )
-
 
         analysis_config = self.ert().analysisConfig()
         analysis_iter_config = analysis_config.getAnalysisIterConfig()
@@ -86,8 +86,6 @@ class IteratedEnsembleSmoother(BaseRunModel):
             if  post_analysis_iter_num > pre_analysis_iter_num:
                 analysis_success = True
 
-
-
             if analysis_success:
                 current_iteration += 1
                 run_context = self.create_context( arguments, current_iteration, prior_context = run_context )
@@ -99,12 +97,12 @@ class IteratedEnsembleSmoother(BaseRunModel):
                 self._runAndPostProcess(run_context)
                 num_tries += 1
 
-
-
         if current_iteration == phase_count:
             self.setPhase(phase_count, "Simulations completed.")
         else:
             raise ErtRunError("Iterated Ensemble Smoother stopped: maximum number of iteration retries (%d retries) reached for iteration %d" % (num_retries_per_iteration, current_iteration))
+
+        return run_context
 
 
     def create_context(self, arguments, itr, prior_context = None, rerun = False):

--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -8,6 +8,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
 
     def __init__(self, queue_config):
         super(IteratedEnsembleSmoother, self).__init__("Iterated Ensemble Smoother", queue_config , phase_count=2)
+        self.support_restart = False
 
     def setAnalysisModule(self, module_name):
         module_load_success = self.ert().analysisConfig().selectModule(module_name)

--- a/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
+++ b/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
@@ -44,7 +44,6 @@ class MultipleDataAssimilation(BaseRunModel):
         if not module_load_success:
             raise ErtRunError("Unable to load analysis module '%s'!" % module_name)
 
-
     def runSimulations(self, arguments):
         context = self.create_context(arguments, 0, None)
         self.checkMinimumActiveRealizations(context)
@@ -79,9 +78,10 @@ class MultipleDataAssimilation(BaseRunModel):
 
         self.setPhase(iteration_count + 2, "Simulations completed.")
 
+        return run_context
+
     def count_active_realizations(self, run_context):
         return sum(run_context.get_mask( ))
-
 
     def update(self, run_context, weight):
         source_fs = run_context.get_sim_fs( )

--- a/python/python/ert_gui/simulation/models/single_test_run.py
+++ b/python/python/ert_gui/simulation/models/single_test_run.py
@@ -14,25 +14,4 @@ class SingleTestRun(EnsembleExperiment):
             raise ErtRunError("Simulation failed!")
 
     def runSimulations(self, arguments):
-        self.runSimulations__( arguments  , "Running single realisation test ...")
-
-    def create_context(self, arguments):
-        fs_manager = self.ert().getEnkfFsManager()
-        result_fs = fs_manager.getCurrentFileSystem( )
-
-        model_config = self.ert().getModelConfig( )
-        runpath_fmt = model_config.getRunpathFormat( )
-        jobname_fmt = model_config.getJobnameFormat( )
-        subst_list = self.ert().getDataKW( )
-        itr = 0
-
-        mask = BoolVector(  default_value = False )
-        mask[0] = True
-        run_context = ErtRunContext.ensemble_experiment(result_fs,
-                                                        mask,
-                                                        runpath_fmt,
-                                                        jobname_fmt,
-                                                        subst_list,
-                                                        itr)
-
-        return run_context
+        return self.runSimulations__( arguments  , "Running single realisation test ...")

--- a/python/python/ert_gui/simulation/single_test_run_panel.py
+++ b/python/python/ert_gui/simulation/single_test_run_panel.py
@@ -15,6 +15,7 @@ from ert_gui.ide.keywords.definitions import RangeStringArgument
 from ert_gui.simulation.models import EnsembleExperiment
 from ert_gui.simulation.models import SingleTestRun
 from ert_gui.simulation.simulation_config_panel import SimulationConfigPanel
+from ecl.util.util import BoolVector
 
 class SingleTestRunPanel(SimulationConfigPanel):
 
@@ -39,5 +40,8 @@ class SingleTestRunPanel(SimulationConfigPanel):
     def toggleAdvancedOptions(self, show_advanced):
         pass
 
+    def getSimulationArguments(self):
+
+        return {"active_realizations": BoolVector(default_value=True, initial_size = 1)}
 
 


### PR DESCRIPTION
This is a possible direction to go. 

The idea is to save the initial state of the active realization mask, and compare it to the completed realization at the end of run_simulations. Then pass back "unfinished realizations". 

The problem with this solution is that the workflow can in theory do anything and create different results if only a subset of realizations are active. This can then, in turn, affect the result of running the FM. 

resolves #195 