### PR TITLE
Remove cmake flag ERT_BUILD_CXX from travis build description

### DIFF
--- a/travis/build_total.py
+++ b/travis/build_total.py
@@ -41,7 +41,6 @@ def build(source_dir, install_dir, test, c_flags, cxx_flags, test_flags=None):
                   source_dir,
                   "-DBUILD_TESTS=ON",
                   "-DENABLE_PYTHON=ON",
-                  "-DERT_BUILD_CXX=ON",
                   "-DINSTALL_CWRAP=OFF",
                   "-DBUILD_APPLICATIONS=ON",
                   "-DCMAKE_INSTALL_PREFIX=%s" % install_dir,


### PR DESCRIPTION
**Task**
Followup to: Statoil/libecl#547 The travis build script used to pass `-DERT_BUILD_CXX=ON` when configuring. The switch is removed in `Statoil/libecl#547`and this is a followup.

This PR and Statoil/libecl#547 are related, but since the `ERT_BUILD_CXX`defaulted to `ON` the two can be merged independently.
