### PR TITLE
Fix bug - use same name for context

### DIFF
--- a/python/python/bin/ert_cli
+++ b/python/python/bin/ert_cli
@@ -86,7 +86,7 @@ def _ensemble_smoother_run(ert):
 
     mask = BoolVector(default_value=True, initial_size=ert.getEnsembleSize())
 
-    run_context = ErtRunContext.ensemble_smoother(
+    prior_context = ErtRunContext.ensemble_smoother(
                                 sim_fs=source_fs,
                                 target_fs=target_fs,
                                 mask=mask,
@@ -96,17 +96,17 @@ def _ensemble_smoother_run(ert):
                                 itr=0)
 
     sim_runner = ert.getEnkfSimulationRunner()
-    _run_ensemble_experiment(ert, run_context, sim_runner)
+    _run_ensemble_experiment(ert, prior_context, sim_runner)
     sim_runner.runWorkflows( HookRuntime.PRE_UPDATE )
 
     es_update = ESUpdate(ert)
-    success = es_update.smootherUpdate(run_context)
+    success = es_update.smootherUpdate(prior_context)
     if not success:
-            raise AssertionError("Analysis of simulation failed!")
+        raise AssertionError("Analysis of simulation failed!")
 
     sim_runner.runWorkflows( HookRuntime.POST_UPDATE )
 
-    ert.getEnkfFsManager().switchFileSystem(run_context.get_target_fs())
+    ert.getEnkfFsManager().switchFileSystem(prior_context.get_target_fs())
 
     sim_fs = prior_context.get_target_fs( )
     state = RealizationStateEnum.STATE_HAS_DATA | RealizationStateEnum.STATE_INITIALIZED

--- a/python/tests/global/test_cli.py
+++ b/python/tests/global/test_cli.py
@@ -1,14 +1,11 @@
 from tests import ErtTest
 from res.test import ErtTestContext
 import os
+import subprocess
 
 class EntryPointTest(ErtTest):
     def test_single_realization(self):
         config_file = self.createTestPath('local/poly_example/poly.ert')
         exec_path = os.path.join(self.SOURCE_ROOT, "python/python/bin/ert_cli")
-        os.execvp(exec_path, [exec_path, config_file, "--algorithm=Test-run"])
-
-    def test_smoother_ensemble(self):
-        config_file = self.createTestPath('local/poly_example/poly.ert')
-        exec_path = os.path.join(self.SOURCE_ROOT, "python/python/bin/ert_cli")
-        os.execvp(exec_path, [exec_path, config_file, "--algorithm=Ensemble Smoother"])
+        ok = subprocess.call([exec_path, config_file, "--algorithm=Test-run"])
+        assert ok == 0


### PR DESCRIPTION
**Task**

Minor bug, might have missed parts of previous commit.

Also removed running smoother ensemble on poly.ert, really isn't
necessary and should receive a better test instead
