### PR TITLE
Iterated bug

### DIFF
--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ configure_file(
 )
 
 add_subdirectory(global)
-
+add_subdirectory(data)
 if (GUI)
    add_subdirectory(gui)
 endif()

--- a/python/tests/data/CMakeLists.txt
+++ b/python/tests/data/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(TEST_SOURCES
+    __init__.py
+    test_data.py
+)
+
+add_python_package("python.tests.data" ${PYTHON_INSTALL_PREFIX}/tests/data "${TEST_SOURCES}" False)
+
+addPythonTest(tests.data.test_data.TestData)

--- a/python/tests/data/test_data.py
+++ b/python/tests/data/test_data.py
@@ -1,0 +1,12 @@
+from tests import ErtTest
+from res.test import ErtTestContext
+
+# The data loaded in this test is not part of an automatic test, we
+# just verify that the example cases can indeed be loaded.
+
+class TestData(ErtTest):
+
+    def test_poly(self):
+        config_file = self.createTestPath('local/poly_example/poly.ert')
+        with ErtTestContext('poly', config_file) as work_area:
+            ert = work_area.getErt()

--- a/test-data/local/poly_example/poly-ies.ert
+++ b/test-data/local/poly_example/poly-ies.ert
@@ -16,3 +16,6 @@ GEN_DATA POLY_RES RESULT_FILE:poly_%d.out REPORT_STEPS:0 INPUT_FORMAT:ASCII
 
 INSTALL_JOB poly_eval POLY_EVAL
 SIMULATION_JOB poly_eval
+-- Load the RML module, this does not imply that it is actually used. That will
+-- be determined by the user interactively later.
+ANALYSIS_LOAD RML rml_enkf.so

--- a/test-data/local/poly_example/poly.ert
+++ b/test-data/local/poly_example/poly.ert
@@ -16,3 +16,6 @@ GEN_DATA POLY_RES RESULT_FILE:poly_%d.out REPORT_STEPS:0 INPUT_FORMAT:ASCII
 
 INSTALL_JOB poly_eval POLY_EVAL
 SIMULATION_JOB poly_eval
+-- Load the RML module, this does not imply that it is actually used. That will
+-- be determined by the user interactively later.
+ANALYSIS_LOAD RML rml_enkf.so


### PR DESCRIPTION
Currently libres/ert has one implementation of an *iterated* smoother - the RML module. This module is quite complex, was from the outset not very well implemented and has had many problems. Partly due to this the gui model class to actually manage/run an iterated smoother has not seen much attention either.

As part of @geirev work: https://github.com/Statoil/libres/pull/422 a significantly improved iterated implementation is on the way, and as preparation for that - this PR fixes a bug in the gui model class for running iterated smoothers.