### PR TITLE
Always show advanced settings

### DIFF
--- a/python/python/ert_gui/main_window.py
+++ b/python/python/ert_gui/main_window.py
@@ -72,15 +72,6 @@ class GertMainWindow(QMainWindow):
         """:type: QMenu"""
 
         """ @rtype: list of QAction """
-        advanced_toggle_action = QAction("Show Advanced Options", self)
-        advanced_toggle_action.setObjectName("AdvancedSimulationOptions")
-        advanced_toggle_action.setCheckable(True)
-        advanced_toggle_action.setChecked(False)
-        advanced_toggle_action.toggled.connect(self.toggleAdvancedMode)
-
-        self.__view_menu.addAction(advanced_toggle_action)
-
-        """ @rtype: list of QAction """
         show_about = self.__help_menu.addAction("About")
         show_about.setMenuRole(QAction.ApplicationSpecificRole)
         show_about.triggered.connect(self.__showAboutMessage)
@@ -112,15 +103,6 @@ class GertMainWindow(QMainWindow):
         else:
             self.restoreGeometry(settings.value("geometry"))
             self.restoreState(settings.value("windowState"))
-
-
-    def toggleAdvancedMode(self, advanced_mode):
-        if hasattr(self.__main_widget, "toggleAdvancedMode"):
-            self.__main_widget.toggleAdvancedMode(advanced_mode)
-
-        for tool in self.tools.values():
-            if hasattr(tool, "toggleAdvancedMode"):
-                tool.toggleAdvancedMode(advanced_mode)
 
 
     def setWidget(self, widget):

--- a/python/python/ert_gui/tools/load_results/load_results_tool.py
+++ b/python/python/ert_gui/tools/load_results/load_results_tool.py
@@ -25,10 +25,7 @@ class LoadResultsTool(Tool):
         super(LoadResultsTool, self).__init__("Load results manually", "tools/load_manually", resourceIcon("ide/table_import"))
         self.__import_widget = None
         self.__dialog = None
-        self.setVisible(False)
-
-
-
+        self.setEnabled(LoadResultsModel.isValidRunPath())
 
     def trigger(self):
         if self.__import_widget is None:
@@ -41,10 +38,3 @@ class LoadResultsTool(Tool):
     def load(self):
         self.__import_widget.load()
         self.__dialog.accept()
-
-    def toggleAdvancedMode(self, advanced_mode):
-        self.setVisible(advanced_mode)
-        if not LoadResultsModel.isValidRunPath():
-            self.setEnabled(False)
-
-

--- a/python/python/ert_gui/tools/run_analysis/run_analysis_tool.py
+++ b/python/python/ert_gui/tools/run_analysis/run_analysis_tool.py
@@ -38,8 +38,6 @@ class RunAnalysisTool(Tool):
         self._run_widget = None
         self._dialog = None
         self._selected_case_name = None
-        self.setVisible(False)
-
 
     def trigger(self):
         if self._run_widget is None:
@@ -53,7 +51,7 @@ class RunAnalysisTool(Tool):
         source = self._run_widget.source_case()
 
         ert = ERT.ert
-        fs_manager = ert.getEnkfFsManager() 
+        fs_manager = ert.getEnkfFsManager()
         es_update = ESUpdate(ert)
 
         target_fs = fs_manager.getFileSystem(target)
@@ -72,6 +70,3 @@ class RunAnalysisTool(Tool):
 
         ERT.ertChanged.emit()
         self._dialog.accept()
-
-    def toggleAdvancedMode(self, advanced_mode):
-        self.setVisible(advanced_mode)


### PR DESCRIPTION
The low number of advanced settings doesn't justify the need to have a
"hide" option - and users could have difficulties navigating.

**Task**
Always show the "Run Analysis" option - closes #196 

